### PR TITLE
Adds deprecation warning for 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-:warning: **This module is deprecated as of release 7.0** :warning:
+** This module has been deprecated in favor of basscss-btn-primary **
 
 This module provides simple, solid button color styles.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+:warning: **This module is deprecated as of release 7.0** :warning:
 
 This module provides simple, solid button color styles.
 
@@ -26,4 +27,3 @@ Or set `--button-background-color` to change the default.
 <button class="button mb1 black bg-darken-3">Button</button>
 <button class="button mb1 bg-darken-4">Button</button>
 ```
-

--- a/index.css
+++ b/index.css
@@ -1,3 +1,4 @@
+/* @deprecated as of release 7.0 */
 /* Basscss Button Solid */
 
 .button {
@@ -34,4 +35,3 @@
   --button-color: white;
   --button-background-color: var(--blue);
 }
-

--- a/index.css
+++ b/index.css
@@ -1,5 +1,5 @@
-/* @deprecated as of release 7.0 */
 /* Basscss Button Solid */
+/* This module has been deprecated in favor of basscss-btn-primary */
 
 .button {
   color: var(--button-color);


### PR DESCRIPTION
Here you go. If it's good I'm gonna do it for :
☐ button-outline
☐ base-buttons
☐ button-sizes
☐ button-link
☐ button-transparent
☐ basscss-button-light-gray
☐ basscss-button-blue-outline
☐ basscss-color-buttons
☐ basscss-button-nav-dark
☐ basscss-button-nav-light
☐ basscss-button-nav-tab
☐ basscss-button-red
☐ basscss-button-gray

Ideally it would be nice to say with what it's replaced or suggest an alternative. You're the boss there ;)
Also regarding npm warning only the owner can do that.

:cocktail: :cocktail: 